### PR TITLE
The Document endpoint was consuming the loop_view_id, not the loop_id

### DIFF
--- a/lib/dotloop/document.rb
+++ b/lib/dotloop/document.rb
@@ -6,18 +6,20 @@ module Dotloop
       @client = client
     end
 
-    def all(profile_id:, loop_id:)
-      @client.get("/profile/#{profile_id.to_i}/loop/#{loop_id.to_i}/document").map do |document_attrs|
+    def all(profile_id:, loop_view_id:)
+      @client.get("/profile/#{profile_id.to_i}/loop/#{loop_view_id.to_i}/document").map do |document_attrs|
         doc = Dotloop::Models::Document.new(document_attrs)
         doc.client = client
         doc
       end
     end
 
-    def get(profile_id:, loop_id:, document_id:, document_name:)
+    def get(profile_id:, loop_view_id:, document_id:, document_name:)
       document_name = CGI.escape(document_name)
       StringIO.new(
-        @client.raw("/profile/#{profile_id.to_i}/loop/#{loop_id.to_i}/document/#{document_id}/#{document_name}.pdf")
+        @client.raw(
+          "/profile/#{profile_id.to_i}/loop/#{loop_view_id.to_i}/document/#{document_id}/#{document_name}.pdf"
+        )
       )
     end
   end

--- a/spec/dotloop/document_spec.rb
+++ b/spec/dotloop/document_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dotloop::Document do
   describe '#all' do
     it 'should return a list of documents' do
       dotloop_mock(:documents)
-      documents = subject.all(profile_id: 1_234, loop_id: 76_046)
+      documents = subject.all(profile_id: 1_234, loop_view_id: 76_046)
       expect(documents).to_not be_empty
       expect(documents).to all(be_a(Dotloop::Models::Document))
       expect(documents.first).to have_attributes(
@@ -38,7 +38,7 @@ RSpec.describe Dotloop::Document do
     it 'should get pdf data' do
       dotloop_pdf
       document = subject.get(profile_id: 1_234,
-                             loop_id: 76_046,
+                             loop_view_id: 76_046,
                              document_id: 561_622,
                              document_name: 'AgencyDisclosureStatementSeller')
       expect(document.string).to eq(disclosure_file_data)


### PR DESCRIPTION
The loop_id was in fact loop_view_id